### PR TITLE
[untested] remove @netlify/plugin-nextjs from config

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -51,7 +51,9 @@ jobs:
       - name: 🚀 Deploy
         id: deploy-netlify
         run: |
-          COMMAND="netlify deploy --build"
+          COMMAND="netlify deploy --build \
+          -m ${{ github.head_ref }} \
+          --alias ${{ github.head_ref }}"
           OUTPUT=$(sh -c "$COMMAND")
 
           NETLIFY_URL=$(echo "$OUTPUT" \

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -51,9 +51,7 @@ jobs:
       - name: 🚀 Deploy
         id: deploy-netlify
         run: |
-          COMMAND="netlify deploy --build \
-          -m ${{ github.head_ref }} \
-          --alias ${{ github.head_ref }}"
+          COMMAND="netlify deploy --build"
           OUTPUT=$(sh -c "$COMMAND")
 
           NETLIFY_URL=$(echo "$OUTPUT" \

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -51,8 +51,8 @@ jobs:
       - name: 🚀 Deploy
         id: deploy-netlify
         run: |
-          COMMAND="netlify deploy \
-          --build -m ${{ github.head_ref }} \
+          COMMAND="netlify deploy --build \
+          -m ${{ github.head_ref }} \
           --alias ${{ github.head_ref }}"
           OUTPUT=$(sh -c "$COMMAND")
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -52,8 +52,7 @@ jobs:
         id: deploy-netlify
         run: |
           COMMAND="netlify deploy --build \
-          -m ${{ github.head_ref }} \
-          --alias ${{ github.head_ref }}"
+          -m ${{ github.head_ref }}"
           OUTPUT=$(sh -c "$COMMAND")
 
           NETLIFY_URL=$(echo "$OUTPUT" \

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # vscode
 .vscode
+
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,5 @@
 [build]
   publish = ".next"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,2 @@
 [build]
   publish = ".next"
-
-[[plugins]]
-  package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
- Refactor: Remove unnecessary @netlify/plugin-nextjs from netlify.toml
- Bugfix: Remove deploy alias for PR previews see [this issue](https://answers.netlify.com/t/netlify-cli-alias-urls-not-found/17831/4)
   
> Context: 
We were using branch names as the "alias" (domain) for the preview deployment. However, if the branch name contains a slash, for eg. (feat/awesomefeature, or fix/someissue), the alias doesn't work and results in a 404.
